### PR TITLE
Fixed flink operator helm deploy failed

### DIFF
--- a/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
+++ b/helm-chart/flink-operator/templates/flink-cluster-crd.yaml
@@ -466,6 +466,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -1750,6 +1751,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -2397,6 +2399,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -3598,6 +3601,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:
@@ -4242,6 +4246,7 @@ spec:
                               type: string
                           required:
                           - containerPort
+                          - protocol
                           type: object
                         type: array
                         x-kubernetes-list-map-keys:


### PR DESCRIPTION
* Fixed helm deploy failed

```
Error: failed to create resource: CustomResourceDefinition.apiextensions.k8s.io "flinkclusters.flinkoperator.k8s.io" is invalid: [spec.validation.openAPIV3Schema.properties[spec].properties[job].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[taskManager].properties[sidecars].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[taskManager].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[jobManager].properties[initContainers].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property, spec.validation.openAPIV3Schema.properties[spec].properties[jobManager].properties[sidecars].items.properties[ports].items.properties[protocol].default: Required value: this property is in x-kubernetes-list-map-keys, so it must have a default or be a required property]

```